### PR TITLE
chore/update project id

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,5 +1,5 @@
 {
   "projects": {
-    "default": "keep.client"
+    "default": "fire-keep"
   }
 }

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -17,6 +17,6 @@ jobs:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_FIRE_KEEP }}'
           channelId: live
-          projectId: keep.client
+          projectId: fire-keep
         env:
           FIREBASE_CLI_PREVIEWS: hostingchannels

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -13,6 +13,6 @@ jobs:
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_FIRE_KEEP }}'
-          projectId: keep.client
+          projectId: fire-keep
         env:
           FIREBASE_CLI_PREVIEWS: hostingchannels


### PR DESCRIPTION
Firebase project id was set to `keep.client`. I switched to `fire-keep` so let's see what happens

Hopefully closes #17 